### PR TITLE
Update index.user.css

### DIFF
--- a/index.user.css
+++ b/index.user.css
@@ -465,15 +465,6 @@ THEME_DARK_AUTO "暗色模式（跟随系统）" <<<EOT
 		.bili-header .right-entry .right-entry-item .right-entry-text {
 			filter: drop-shadow(0 0 3px rgba(0, 0, 0, .3));
 		}
-		.bili-header .right-entry__outside .right-entry-icon,
-        .bili-header .bili-header__bar .right-entry__outside .right-entry-text,
-		.bili-header .right-entry .right-entry-item .right-entry-text {
-			color: white;
-		}
-		.bili-header .slide-down .right-entry__outside .right-entry-icon,
-		.bili-header .slide-down .right-entry .right-entry-item .right-entry-text {
-			color: var(--a-text-1)!important;
-		}
     EOT;
 }
 


### PR DESCRIPTION
删去部分多余的CSS。
![AA$7$L@L2FGETHB 8UNA7(9](https://user-images.githubusercontent.com/55832499/209419086-856275fe-ead1-4c11-9b86-6ee28c706584.png)
选取“顶栏设计效果：效果2（胶囊模式）”时这部分样式会被“顶栏右侧文字颜色设计”的选项覆盖，所以对整体效果无影响，因此删去。
![IJ`BLRTHT$Z6PB@U)1}7~KN](https://user-images.githubusercontent.com/55832499/209419091-d0ad3bf0-dde3-4dcc-b2f8-4979a7d17ef6.png)